### PR TITLE
Correct install script in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cd ../..
 # Add xilinx board support
 cd archs/otawa-xilinx
 cmake -DCMAKE_INSTALL_PREFIX=$OTAWA_INSTALL_DIR . && make install
-cd ../..
+cd ..
 
 # Extra ARM boards support
 cd otawa-STM32F427


### PR DESCRIPTION
Really minor change, I assume when some new architectures were added to Otawa they were pasted on the end and this got missed. 